### PR TITLE
Fix request timeout

### DIFF
--- a/lib/auth0/mixins/httpproxy.rb
+++ b/lib/auth0/mixins/httpproxy.rb
@@ -68,7 +68,7 @@ module Auth0
       rescue RestClient::Exception => e
         case e
         when RestClient::RequestTimeout
-          raise Auth0::RequestTimeout
+          raise Auth0::RequestTimeout.new(e.message)
         else
           return e.response
         end

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -67,7 +67,7 @@ describe Auth0::Mixins::HTTPProxy do
       end
 
       it "should raise Auth0::RequestTimeout on send http #{http_method} method
-        to path defined through HTTP when 408 status received" do
+        to path defined through HTTP when RestClient::RequestTimeout received" do
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
                                                              url: '/test',
                                                              timeout: nil,
@@ -242,7 +242,7 @@ describe Auth0::Mixins::HTTPProxy do
       end
 
       it "should raise Auth0::RequestTimeout on send http #{http_method} method
-        to path defined through HTTP when 408 status received" do
+        to path defined through HTTP when RestClient::RequestTimeout received" do
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
                                                              url: '/test',
                                                              timeout: nil,

--- a/spec/lib/auth0/mixins/httpproxy_spec.rb
+++ b/spec/lib/auth0/mixins/httpproxy_spec.rb
@@ -66,8 +66,19 @@ describe Auth0::Mixins::HTTPProxy do
         expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::Unsupported)
       end
 
+      it "should raise Auth0::RequestTimeout on send http #{http_method} method
+        to path defined through HTTP when 408 status received" do
+        allow(RestClient::Request).to receive(:execute).with(method: http_method,
+                                                             url: '/test',
+                                                             timeout: nil,
+                                                             headers: { params: {} },
+                                                             payload: nil)
+          .and_raise(RestClient::Exceptions::OpenTimeout.new)
+        expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::RequestTimeout)
+      end
+
       it "should raise Auth0::BadRequest on send http #{http_method} method
-        to path defined through HTTP when 400 or other unknown status received" do
+        to path defined through HTTP when 400 status received" do
         @exception.response = StubResponse.new({}, false, 400)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
                                                              url: '/test',
@@ -230,8 +241,19 @@ describe Auth0::Mixins::HTTPProxy do
         expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::Unsupported)
       end
 
+      it "should raise Auth0::RequestTimeout on send http #{http_method} method
+        to path defined through HTTP when 408 status received" do
+        allow(RestClient::Request).to receive(:execute).with(method: http_method,
+                                                             url: '/test',
+                                                             timeout: nil,
+                                                             headers: nil,
+                                                             payload: '{}')
+          .and_raise(RestClient::Exceptions::OpenTimeout.new)
+        expect { @instance.send(http_method, '/test') }.to raise_error(Auth0::RequestTimeout)
+      end
+
       it "should raise Auth0::BadRequest on send http #{http_method} method
-        to path defined through HTTP when 400 or other unknown status received" do
+        to path defined through HTTP when 400 status received" do
         @exception.response = StubResponse.new({}, false, 400)
         allow(RestClient::Request).to receive(:execute).with(method: http_method,
                                                              url: '/test',


### PR DESCRIPTION
### Changes
#170  changed the initialization of the Auth0::Exception class, but Auth0::RequestTimeout was not changed.

### References

### Testing

* [x] This change adds unit test coverage
* [ ] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
* [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
* [x] All existing and new tests complete without errors
* [ ] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed